### PR TITLE
Add Bower package support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,15 @@
+{
+  "name": "ramjet",
+  "homepage": "http://www.rich-harris.co.uk/ramjet/",
+  "authors": [
+    "Rich Harris <richard.a.harris@gmail.com>"
+  ],
+  "description": "Transform DOM elements into each another with smooth transitions",
+  "main": "dist/ramjet.js",
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "scripts",
+    "test"
+  ]
+}


### PR DESCRIPTION
Hey,

I've added `bower.json` to the root of the repo to allow ramjet to be installed easily by Bower users.

Once merged, the package just needs to be registered with Bower:
`bower register ramjet git://github.com/Rich-Harris/ramjet.git`