### PR TITLE
Add a preprocess function to control the cloned node

### DIFF
--- a/src/ramjet.js
+++ b/src/ramjet.js
@@ -15,8 +15,12 @@ export default {
 			options.duration = 400;
 		}
 
-		const from = wrapNode( fromNode );
-		const to = wrapNode( toNode );
+		if ( !( 'visionNodesHandler' in options ) ) {
+			options.vNodesHandler = () => {};
+		}
+
+		const from = wrapNode( fromNode , vNodesHandler);
+		const to = wrapNode( toNode , vNodesHandler);
 
 		if ( from.isSvg || to.isSvg && !appendedSvg ) {
 			appendSvg();

--- a/src/utils/node.js
+++ b/src/utils/node.js
@@ -26,13 +26,15 @@ export function cloneNode ( node ) {
 	return clone;
 }
 
-export function wrapNode ( node ) {
+export function wrapNode ( node , vNodesHandler) {
 	const isSvg = node.namespaceURI === svgns;
 
 	const { left, right, top, bottom } = node.getBoundingClientRect();
 	const style = window.getComputedStyle( node );
 
 	const clone = cloneNode( node );
+
+	vNodesHandler(clone);
 
 	const wrapper = {
 		node, clone, isSvg,


### PR DESCRIPTION
When ramjet clone a node without clean up some attributes may cause issues.
eg. 
`data-reactid` - duplicate React.js dom id

```js
ramjet.transform( from, to, {
	visionNodesHandler: function(vNode){
		if(vNode.removeAttribute){
			vNode.removeAttribute('data-reactid');
		}
	}
});
```