### PR TITLE
use offsetParent for correct position of children of statically positioned nodes

### DIFF
--- a/test/samples/relative-inside-static.html
+++ b/test/samples/relative-inside-static.html
@@ -1,0 +1,4 @@
+<div>
+	<div class='a' style='position: relative;'>a</div>
+</div>
+<div class='b'>b</div>

--- a/test/samples/relative-inside-transformed-static.html
+++ b/test/samples/relative-inside-transformed-static.html
@@ -1,0 +1,6 @@
+<div>
+	<div style='transform: rotate(30deg) translate(20px,20px);'>
+		<div class='a' style='position: relative;'>a</div>
+	</div>
+</div>
+<div class='b'>b</div>


### PR DESCRIPTION
**not ready for merge**

Wild things start happening when you transform descendants of statically positioned nodes, because the absolute positioning (which is necessary to avoid insane layout glitches) is calculated on the wrong basis (`node.parentNode` rather than `node.offsetParent`). This fixes that, but it introduces another bug – if you have transformed nodes *between* the offset parent and the transformed node, the transforms aren't correctly applied.