### PR TITLE
Fixed: ES6 version was actually compiled to ES5

### DIFF
--- a/gobblefile.js
+++ b/gobblefile.js
@@ -19,7 +19,6 @@ var lib = gobble([
 		entry: 'ramjet.js',
 		dest: 'ramjet.es6.js',
 		format: 'es6',
-		plugins: [ babel({ include: 'src/**' }), npm({ jsnext: true }) ],
 		sourceMap: true
 	})
 ]);


### PR DESCRIPTION
jsnext:main pointed to a compiled version, in ES5.